### PR TITLE
cmd/scrappy: tolerate trailing / in -u flag

### DIFF
--- a/cmd/scrappy/main.go
+++ b/cmd/scrappy/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 
 	"github.com/bobrik/scrappy/mesos"
@@ -23,7 +24,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	state, err := mesos.GetState(*u)
+	mesosUrl, err := url.Parse(*u)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	state, err := mesos.GetState(mesosUrl)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 )
 
 // State represents Mesos cluster state
@@ -60,8 +61,9 @@ type Slave struct {
 }
 
 // GetState returns Mesos master state from requested URL
-func GetState(u string) (*State, error) {
-	r, err := http.Get(fmt.Sprintf("%s/master/state", u))
+func GetState(u *url.URL) (*State, error) {
+	u.Path = "/master/state"
+	r, err := http.Get(u.String())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Update scrappy to tolerate users who include
  a trailing / in the mesos URL

I'm not sure if it's more idiomatic to pass url strings or URL structs to things in go, so if this is better being parsed in mesos.go instead of main(), just let me know. Thanks for the tool!
