### PR TITLE
Add Mesos resource breakdown by attribute KV pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ The following options are available:
 
 * `-u` Mesos URL to fetch data from.
 * `-f` role name to filter on.
+
+### Attributes
+
+`attributes` reports resource usage grouped by attribute key-value pairs:
+
+```
+docker run --rm bobrik/scrappy attributes -u http://mesos-master:port
+```
+
+Sample report showing just one attribute:
+
+```
+attribute CPUs used CPUs total     CPU %  RAM used RAM total     RAM %
+ rack=101      0.30       2.00    15.00%    0.12GB    0.98GB    12.79%
+```
+
+The following options are available:
+
+* `-u` Mesos URL to fetch data from.
+* `-f` role name to filter on.

--- a/cmd/scrappy-attributes/main.go
+++ b/cmd/scrappy-attributes/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/bobrik/scrappy/mesos"
+	"github.com/bobrik/scrappy/report"
+)
+
+func main() {
+	u := flag.String("u", "", "mesos url (http://host:port)")
+	f := flag.String("f", "", "role name to filter on")
+
+	flag.Parse()
+
+	if *u == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	mesosUrl, err := url.Parse(*u)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	state, err := mesos.GetState(mesosUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rep := report.Generate(state, *f)
+
+	attributes := make(map[string]*report.Attribute)
+	ids := []string{}
+
+	for _, slave := range rep.Slaves {
+		for k, v := range slave.Attributes {
+			id := fmt.Sprintf("%s=%v", k, v)
+
+			if _, ok := attributes[id]; !ok {
+				attributes[id] = &report.Attribute{
+					Key:                k,
+					Value:              v,
+					AvailableResources: mesos.Resources{},
+					AllocatedResources: mesos.Resources{},
+				}
+
+				ids = append(ids, id)
+			}
+
+			attributes[id].AvailableResources.Add(slave.AvailableResources)
+			attributes[id].AllocatedResources.Add(slave.AllocatedResources)
+		}
+	}
+
+	sort.Strings(ids)
+
+	w := &tabwriter.Writer{}
+	w.Init(os.Stdout, 10, 0, 1, ' ', tabwriter.AlignRight)
+
+	w.Write([]byte("attribute\tCPUs used\tCPUs total\tCPU %\tRAM used\tRAM total\tRAM %\t\n"))
+
+	for _, id := range ids {
+		attribute := attributes[id]
+		fmt.Fprintf(
+			w,
+			"%s\t%.2f\t%.2f\t%.2f%%\t%.2fGB\t%.2fGB\t%.2f%%\t\n",
+			id,
+			attribute.AllocatedResources.CPUs,
+			attribute.AvailableResources.CPUs,
+			attribute.AllocatedResources.CPUs/attribute.AvailableResources.CPUs*100,
+			attribute.AllocatedResources.Memory/1024,
+			attribute.AvailableResources.Memory/1024,
+			attribute.AllocatedResources.Memory/attribute.AvailableResources.Memory*100,
+		)
+	}
+
+	w.Flush()
+}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,8 +6,9 @@ shift
 
 if [ -z "${FLAVOR}" ]; then
   echo "usage:" 1>&2
-  echo " slaves <flags>" 1>&2
-  echo " roles  <flags>" 1>&2
+  echo " slaves     <flags>" 1>&2
+  echo " roles      <flags>" 1>&2
+  echo " attributes <flags>" 1>&2
   exit 1
 fi
 

--- a/report/report.go
+++ b/report/report.go
@@ -32,6 +32,14 @@ func (s Slave) SortString() string {
 	return fmt.Sprintf("%010s%s%010s", p[1], p[2], p[3])
 }
 
+// Attribute represents a key-value attribute in the report
+type Attribute struct {
+	Key                string          `json:"key"`
+	Value              interface{}     `json:"value"`
+	AvailableResources mesos.Resources `json:"available_resources"`
+	AllocatedResources mesos.Resources `json:"allocated_resources"`
+}
+
 // Role represents role's state in the report
 type Role struct {
 	Name               string          `json:"name"`


### PR DESCRIPTION
Add a new command that produces a breakdown of Mesos resources used,
grouped by attribute key-value pairs:
http://mesos.apache.org/documentation/latest/attributes-resources/

For example, if `rack` is an attribute assigned to Mesos agents, this
report will output the resources allocated and available in each rack.

Filtering by role is also supported, which is useful for seeing how well
resources are distributed by attribute (e.g. rack).