### PR TITLE
Use modern terminology: rename slaves to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ It'd be nice to see that information exposed in Mesos UI nicely too.
 Scrappy comes in a Docker container. Just point it to your Mesos master URL
 to get resource usage breakdown. There are two flavors available.
 
-### Slaves
+### Agents
 
-`slaves` flavor reports stats on slave level:
+`agents` flavor reports stats on agent level:
 
 ```
-docker run --rm bobrik/scrappy slaves -u http://mesos-master:port
+docker run --rm bobrik/scrappy agents -u http://mesos-master:port
 ```
 
 Sample report for you to know what to expect:

--- a/cmd/scrappy-agents/main.go
+++ b/cmd/scrappy-agents/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	u := flag.String("u", "", "mesos url (http://host:port)")
-	s := flag.String("s", "host", "sort order for slaves: host, cpu, cpu_percent, mem, mem_percent, tasks")
+	s := flag.String("s", "host", "sort order for agents: host, cpu, cpu_percent, mem, mem_percent, tasks")
 	r := flag.Bool("r", false, "reverse order")
 	f := flag.String("f", "", "role name to filter on")
 
@@ -35,13 +35,13 @@ func main() {
 	}
 
 	rep := report.Generate(state, *f)
-	report.SortSlaves(rep.Slaves, *s, *r)
+	report.SortAgents(rep.Agents, *s, *r)
 
-	for i, slave := range rep.Slaves {
-		fmt.Printf("%s: %s / %s (%v)\n", slave.Hostname, slave.AllocatedResources.String(), slave.AvailableResources.String(), slave.Attributes)
+	for i, agent := range rep.Agents {
+		fmt.Printf("%s: %s / %s (%v)\n", agent.Hostname, agent.AllocatedResources.String(), agent.AvailableResources.String(), agent.Attributes)
 
 		fmt.Printf("  roles:\n")
-		for _, role := range slave.Roles {
+		for _, role := range agent.Roles {
 			fmt.Printf("    - %s: %s / %s\n", role.Name, role.AllocatedResources.String(), role.AvailableResources.String())
 			fmt.Printf("      tasks: %d\n", len(role.Tasks))
 			for _, task := range role.Tasks {
@@ -49,7 +49,7 @@ func main() {
 			}
 		}
 
-		if i < len(rep.Slaves)-1 {
+		if i < len(rep.Agents)-1 {
 			fmt.Println()
 		}
 	}

--- a/cmd/scrappy-roles/main.go
+++ b/cmd/scrappy-roles/main.go
@@ -39,8 +39,8 @@ func main() {
 	roles := map[string]*report.Role{}
 	names := []string{}
 
-	for _, slave := range rep.Slaves {
-		for _, role := range slave.Roles {
+	for _, agent := range rep.Agents {
+		for _, role := range agent.Roles {
 			if _, ok := roles[role.Name]; !ok {
 				roles[role.Name] = &report.Role{
 					Name:               role.Name,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,8 +6,13 @@ shift
 
 if [ -z "${FLAVOR}" ]; then
   echo "usage:" 1>&2
-  echo " slaves <flags>" 1>&2
+  echo " agents <flags>" 1>&2
   echo " roles  <flags>" 1>&2
+  exit 1
+fi
+
+if [ "${FLAVOR}" = "slaves" ]; then
+  echo "The 'slaves' command has been replaced by the 'agents' command." 1>&2
   exit 1
 fi
 

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -11,7 +11,7 @@ import (
 // State represents Mesos cluster state
 type State struct {
 	Frameworks []Framework `json:"frameworks"`
-	Slaves     []Slave     `json:"slaves"`
+	Agents     []Agent     `json:"slaves"`
 }
 
 // Framework represents framework info from Mesos cluster state
@@ -26,7 +26,7 @@ type Framework struct {
 type Task struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
-	SlaveID   string    `json:"slave_id"`
+	AgentID   string    `json:"slave_id"`
 	State     string    `json:"state"`
 	Resources Resources `json:"resources"`
 }
@@ -47,8 +47,8 @@ func (r *Resources) Add(more Resources) {
 	r.Memory += more.Memory
 }
 
-// Slave represents slave info from Mesos cluster state
-type Slave struct {
+// Agent represents agent info from Mesos cluster state
+type Agent struct {
 	ID         string                 `json:"id"`
 	Hostname   string                 `json:"hostname"`
 	Attributes map[string]interface{} `json:"attributes"`

--- a/report/sort.go
+++ b/report/sort.go
@@ -11,47 +11,47 @@ const (
 	tasksOrder      = "tasks"
 )
 
-// SortSlaves sorts slaves in the desired order
-func SortSlaves(slaves []*Slave, order string, reverse bool) {
+// SortAgents sorts agents in the desired order
+func SortAgents(agents []*Agent, order string, reverse bool) {
 	switch order {
 	case hostOrder:
-		sort.Sort(slaveSorter{slaves: slaves, less: lessHost})
+		sort.Sort(agentSorter{agents: agents, less: lessHost})
 	case cpuOrder:
-		sort.Sort(slaveSorter{slaves: slaves, less: lessCPU})
+		sort.Sort(agentSorter{agents: agents, less: lessCPU})
 	case cpuPercentOrder:
-		sort.Sort(slaveSorter{slaves: slaves, less: lessCPUPercent})
+		sort.Sort(agentSorter{agents: agents, less: lessCPUPercent})
 	case memOrder:
-		sort.Sort(slaveSorter{slaves: slaves, less: lessMem})
+		sort.Sort(agentSorter{agents: agents, less: lessMem})
 	case memPercentOrder:
-		sort.Sort(slaveSorter{slaves: slaves, less: lessMemPercent})
+		sort.Sort(agentSorter{agents: agents, less: lessMemPercent})
 	case tasksOrder:
-		sort.Sort(slaveSorter{slaves: slaves, less: lessTasks})
+		sort.Sort(agentSorter{agents: agents, less: lessTasks})
 	}
 
 	if reverse {
-		for i := len(slaves)/2 - 1; i >= 0; i-- {
-			opp := len(slaves) - 1 - i
-			slaves[i], slaves[opp] = slaves[opp], slaves[i]
+		for i := len(agents)/2 - 1; i >= 0; i-- {
+			opp := len(agents) - 1 - i
+			agents[i], agents[opp] = agents[opp], agents[i]
 		}
 	}
 }
 
-// slaveSorter is a helper structure to implement Slave sorters.
-// users have to supply a slice of slaves and less fuction
+// agentSorter is a helper structure to implement Agent sorters.
+// users have to supply a slice of agents and less fuction
 // equivalent to Less() method of sort.Sorter interface
-type slaveSorter struct {
-	slaves []*Slave
-	less   func(*Slave, *Slave) bool
+type agentSorter struct {
+	agents []*Agent
+	less   func(*Agent, *Agent) bool
 }
 
-func (s slaveSorter) Len() int {
-	return len(s.slaves)
+func (s agentSorter) Len() int {
+	return len(s.agents)
 }
 
-func (s slaveSorter) Swap(i, j int) {
-	s.slaves[i], s.slaves[j] = s.slaves[j], s.slaves[i]
+func (s agentSorter) Swap(i, j int) {
+	s.agents[i], s.agents[j] = s.agents[j], s.agents[i]
 }
 
-func (s slaveSorter) Less(i, j int) bool {
-	return s.less(s.slaves[i], s.slaves[j])
+func (s agentSorter) Less(i, j int) bool {
+	return s.less(s.agents[i], s.agents[j])
 }

--- a/report/sort_cpu.go
+++ b/report/sort_cpu.go
@@ -1,6 +1,6 @@
 package report
 
-// lessCPU compares two slaves in terms of CPU usage
-func lessCPU(i *Slave, j *Slave) bool {
+// lessCPU compares two agents in terms of CPU usage
+func lessCPU(i *Agent, j *Agent) bool {
 	return i.AllocatedResources.CPUs < j.AllocatedResources.CPUs
 }

--- a/report/sort_cpu_percent.go
+++ b/report/sort_cpu_percent.go
@@ -1,7 +1,7 @@
 package report
 
-// lessCPUPercent compares two slaves in terms of CPU usage in percents
-func lessCPUPercent(i *Slave, j *Slave) bool {
+// lessCPUPercent compares two agents in terms of CPU usage in percents
+func lessCPUPercent(i *Agent, j *Agent) bool {
 	pi := i.AllocatedResources.CPUs / i.AvailableResources.CPUs
 	pj := j.AllocatedResources.CPUs / j.AvailableResources.CPUs
 	return pi < pj

--- a/report/sort_host.go
+++ b/report/sort_host.go
@@ -8,8 +8,8 @@ import (
 // validHostname is a regexp for for hostnames like <DATACENTERC><TYPE><NUMBER>
 var validHostname = regexp.MustCompile(`^(\d+)([a-z]+)(\d+)`)
 
-// lessHost compares two slaves by comparing their hostnames
-func lessHost(i *Slave, j *Slave) bool {
+// lessHost compares two agents by comparing their hostnames
+func lessHost(i *Agent, j *Agent) bool {
 	if strings.Compare(i.SortString(), j.SortString()) == -1 {
 		return true
 	}

--- a/report/sort_mem.go
+++ b/report/sort_mem.go
@@ -1,6 +1,6 @@
 package report
 
-// lessMem compares two slaves in terms of memory usage
-func lessMem(i *Slave, j *Slave) bool {
+// lessMem compares two agents in terms of memory usage
+func lessMem(i *Agent, j *Agent) bool {
 	return i.AllocatedResources.Memory < j.AllocatedResources.Memory
 }

--- a/report/sort_mem_percent.go
+++ b/report/sort_mem_percent.go
@@ -1,7 +1,7 @@
 package report
 
-// lessMemPercent compares two slaves in terms of memory usage in percents
-func lessMemPercent(i *Slave, j *Slave) bool {
+// lessMemPercent compares two agents in terms of memory usage in percents
+func lessMemPercent(i *Agent, j *Agent) bool {
 	pi := i.AllocatedResources.Memory / i.AvailableResources.Memory
 	pj := j.AllocatedResources.Memory / j.AvailableResources.Memory
 	return pi < pj

--- a/report/sort_tasks.go
+++ b/report/sort_tasks.go
@@ -1,15 +1,15 @@
 package report
 
-// lessTasks compares two slaves in terms of running task count
-func lessTasks(i *Slave, j *Slave) bool {
+// lessTasks compares two agents in terms of running task count
+func lessTasks(i *Agent, j *Agent) bool {
 	return numberOfTasks(i) < numberOfTasks(j)
 }
 
-// numberOfTasks returns number of tasks on the given slave
-func numberOfTasks(slave *Slave) int {
+// numberOfTasks returns number of tasks on the given agent
+func numberOfTasks(agent *Agent) int {
 	c := 0
 
-	for _, r := range slave.Roles {
+	for _, r := range agent.Roles {
 		c += len(r.Tasks)
 	}
 


### PR DESCRIPTION
Mesos started using 'agent' rather than 'slave' as of Mesos version 1.0:
https://issues.apache.org/jira/browse/MESOS-1478

Regardless of whether Scrappy supports that version, it's 2018 and we
should use modern and appropriate terminology that doesn't alienate
people.

When the old 'slaves' command is used, an error will be printed and the
program will exit. I considered adding a deprecation warning, but I
don't think it's worth it as Scrappy has no official releases and users
should not be surprised by backwards-incompatible changes.