### PR TITLE
Upgrade Go to version 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
+  - "1.10"
   - tip
 
 sudo: required


### PR DESCRIPTION
Quotes are necessary because YAML parsers would interpret the unquoted
value as as a float (`1.1`).