### PR TITLE
Add awareness of MULTI_ROLE, and hacks to work around mesos behaviours for it

### DIFF
--- a/cmd/scrappy-roles/main.go
+++ b/cmd/scrappy-roles/main.go
@@ -73,20 +73,20 @@ func main() {
 	// there should be a saner way to do this with fmt.sprintf....
 	cpu_s := fmt.Sprintf("%f", *c)
 	cpu_s = strings.TrimRight(strings.TrimRight(cpu_s, "0"), ".")
-	w.Write([]byte(fmt.Sprintf("role\tCPUs used\tCPUs total\tCPU %%\tRAM used\tRAM total\tRAM %%\tOffers remaining for %.fMB, %s CPU\t\n", *m, cpu_s)))
+	w.Write([]byte(fmt.Sprintf("role\tCPUs %%\tused/total\tRAM %%\tused/total\tOffers for %.fMB, %s CPU\t\n", *m, cpu_s)))
 
 	for _, name := range names {
 		role := roles[name]
 		fmt.Fprintf(
 			w,
-			"%s\t%.2f\t%.2f\t%.2f%%\t%.2fGB\t%.2fGB\t%.2f%%\t%d\t\n",
+			"%s\t%.2f%%\t%.2f/%.2f\t%.2f%%\t%.2f/%.2fGB\t%d\t\n",
 			role.Name,
+			role.AllocatedResources.CPUs/role.AvailableResources.CPUs*100,
 			role.AllocatedResources.CPUs,
 			role.AvailableResources.CPUs,
-			role.AllocatedResources.CPUs/role.AvailableResources.CPUs*100,
+			role.AllocatedResources.Memory/role.AvailableResources.Memory*100,
 			role.AllocatedResources.Memory/1024,
 			role.AvailableResources.Memory/1024,
-			role.AllocatedResources.Memory/role.AvailableResources.Memory*100,
 			resource_offers[role.Name],
 		)
 	}

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -26,6 +26,7 @@ type Framework struct {
 type Task struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
+	Role      string    `json:"role"`
 	SlaveID   string    `json:"slave_id"`
 	State     string    `json:"state"`
 	Resources Resources `json:"resources"`


### PR DESCRIPTION
In particular, if a marathon framework has a default role of 'storage', that framework
still implicitly gets '*' role subscriptions.  Tasks in that marathon can
explicitly uses '*' via setting `acceptedResourceRoles=['*']`, and the task's
'role' in the mesos /master/state will still be 'storage'.

This is a bug in mesos in my view, but it occurs- and was causing scrappy
to segfault when it tried to access a non-existent role for the given slave.

The 'hack' for this is that if the role specified by the task doesn't exist on
the host, assume it's an implicit '*' and use that.